### PR TITLE
fix: backslash conversion in Ascii-to-Native

### DIFF
--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -1,25 +1,49 @@
 import * as assert from 'assert';
 import * as utils from '../../utils';
 
+const dataList: Array<{native: string, ascii: string, upperCase?: boolean}> = [
+  {
+    native: '',
+    ascii: ''
+  },
+  {
+    native: 'ABC 123=!"#$%&\'()=^|',
+    ascii: 'ABC 123=!"#$%&\'()=^|'
+  },
+  {
+    native: 'あいうえお',
+    ascii: '\\u3042\\u3044\\u3046\\u3048\\u304a'
+  },
+  {
+    native: 'あ1い2う3え4お',
+    ascii: '\\u30421\\u30442\\u30463\\u30484\\u304a'
+  },
+  {
+    native: '𠀋',
+    ascii: '\\ud840\\udc0b'
+  },
+  {
+    native: '𠀋お',
+    ascii: '\\uD840\\uDC0B\\u304A',
+    upperCase: true
+  },
+  {
+    native: '¡ ÿ',
+    ascii: '\\u00a1 \\u00ff'
+  },
+];
+
 suite('utils Test Suite', () => {
 
-	test('nativeToAscii test', () => {
-    assert.equal('', utils.nativeToAscii(''));
-    assert.equal('ABC 123=!"#$%&\'()=^|', utils.nativeToAscii('ABC 123=!"#$%&\'()=^|'));
-    assert.equal('\\u3042\\u3044\\u3046\\u3048\\u304a', utils.nativeToAscii('あいうえお'));
-    assert.equal('\\u30421\\u30442\\u30463\\u30484\\u304a', utils.nativeToAscii('あ1い2う3え4お'));
-    assert.equal('\\ud840\\udc0b', utils.nativeToAscii('𠀋'));
-    assert.equal('\\uD840\\uDC0B\\u304A', utils.nativeToAscii('𠀋お', false));
-    assert.equal('\\u00a1 \\u00ff', utils.nativeToAscii('¡ ÿ'));
+  test('nativeToAscii test', () => {
+    dataList.forEach(data => {
+      assert.equal(data.ascii, utils.nativeToAscii(data.native, !data.upperCase));
+    });
   });
 
-	test('asciiToNative test', () => {
-    assert.equal('', utils.nativeToAscii(''));
-    assert.equal('ABC 123=!"#$%&\'()=^|', utils.asciiToNative('ABC 123=!"#$%&\'()=^|'));
-    assert.equal('あいうえお', utils.asciiToNative('\\u3042\\u3044\\u3046\\u3048\\u304a'));
-    assert.equal('あ1い2う3え4お', utils.asciiToNative('\\u30421\\u30442\\u30463\\u30484\\u304a'));
-    assert.equal('𠀋', utils.asciiToNative('\\ud840\\udc0b'));
-    assert.equal('𠀋お', utils.asciiToNative('\\uD840\\uDC0B\\u304A'));
-    assert.equal('¡ ÿ', utils.asciiToNative('\\u00a1 \\u00ff'));
+  test('asciiToNative test', () => {
+    dataList.forEach(data => {
+      assert.equal(data.native, utils.asciiToNative(data.ascii));
+    });
   });
 });

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -31,6 +31,14 @@ const dataList: Array<{native: string, ascii: string, upperCase?: boolean}> = [
     native: '¡ ÿ',
     ascii: '\\u00a1 \\u00ff'
   },
+  {
+    native: '\\',
+    ascii: '\\'
+  },
+  {
+    native: '\\/mnt\\/record\\',
+    ascii: '\\/mnt\\/record\\'
+  }
 ];
 
 suite('utils Test Suite', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,7 +42,7 @@ export const nativeToAscii = (text : string, lowerCase : boolean = true) : strin
 
 // Unicode形式からデコードする
 export const asciiToNative = (text : string) : string => {
-  return unescape(text.replace(/\\/g, '%'));
+  return unescape(text.replace(/\\(?=u[0-9A-Za-z])/g, '%'));
 };
 
 // アクティブテキストエディターを取得する


### PR DESCRIPTION
char '\' will convert to char '%' when it uses alone.
e.g. "\/mnt\/record" will convert to "%/mnt%/record"