### PR TITLE
feat: allow conversion of selected text only

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,7 @@ const convertNativeToAscii = () : void => {
   const lowerCase = utils.getConfigParameter('letter-case') === 'Lower case';
   const commentConversion = utils.getConfigParameter('comment-conversion');
 
-  const newText = utils.getFullText()
+  const newText = utils.getText()
     .split(/\r?\n/g)
     .map(line => {
       if (!commentConversion && line.startsWith(COMMENT_PREFIX)) {
@@ -40,13 +40,13 @@ const convertNativeToAscii = () : void => {
     })
     .join(utils.getEol());
 
-  utils.setFullText(newText);
+  utils.setText(newText);
 };
 
 // アクティブドキュメントの内容をUnicodeデコード変換する
 const convertAsciiToNative = () : void => {
-  const newText = utils.asciiToNative(utils.getFullText());
-  utils.setFullText(newText);
+  const newText = utils.asciiToNative(utils.getText());
+  utils.setText(newText);
 };
 
 // 変換処理関数をラップして、エラーハンドリングを行う

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,16 @@ export const getFullText = () : string => {
   return getDocument().getText();
 };
 
+// Get the currently selected text
+export const getSelectedText = () : string => {
+  return getDocument().getText(getSelectionRange());
+};
+
+// Get either the text of the entire file or selected text based on context
+export const getText = () : string => {
+  return isTextSelected() ? getSelectedText() : getFullText();
+};
+
 // アクティブテキストファイルの全内容を置き換える
 export const setFullText = (newText : string) : void => {
   
@@ -18,6 +28,27 @@ export const setFullText = (newText : string) : void => {
 
   // 中途半端に選択された状態になるので、選択を解除する
   editor.selection = new vscode.Selection(0, 0, 0, 0);
+};
+
+// Replace the content of the currently selected text
+export const setSelectedText = (newText : string) : void => {
+  const document = getDocument();
+  const selectionRange = document.validateRange(getSelectionRange());
+
+  const editor = getEditor();
+  editor.edit(builder => builder.replace(selectionRange, newText));
+
+  // 中途半端に選択された状態になるので、選択を解除する
+  editor.selection = new vscode.Selection(0, 0, 0, 0);
+};
+
+// Either replace text of the entire file or selected text based on context
+export const setText = (newText : string) : void => {
+  if (isTextSelected()) {
+    setSelectedText(newText);
+  } else {
+    setFullText(newText);
+  }
 };
 
 // Unicode形式にエンコードする
@@ -54,6 +85,12 @@ export const getEditor = () : vscode.TextEditor => {
   throw new Error('Text editor is not active.');
 };
 
+export const getSelectionRange = () : vscode.Range => {
+  const selection =  getEditor().selection;
+
+  return new vscode.Range(selection.start.line, selection.start.character, selection.end.line, selection.end.character);
+};
+
 // アクティブテキストエディターのドキュメントを取得する
 export const getDocument = () : vscode.TextDocument => {
   const editor = getEditor();
@@ -80,6 +117,10 @@ export const isActiveDocumentPropertiesFile = () : boolean => {
     return document.fileName.endsWith('.properties');
   }
 };
+
+export const isTextSelected = () : boolean => {
+  return !getEditor().selection.isEmpty;
+}
 
 // 設定パラメータを取得する
 export const getConfigParameter = (name : string) : any => {


### PR DESCRIPTION
This change will introduce a new behavior, which is allowing to convert native to ascii and vice versa for selected text only.

- When text is currently selected and you run the conversion command, only the selected text will be converted.
- When no text is selected, you will have the current behavior, which will convert the entire file.  